### PR TITLE
Fix "unreachable pattern" error

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -511,7 +511,6 @@ impl Node {
                 }
             }
             Base(_) => panic!("encountered base page in middle of chain"),
-            _ => unimplemented!(),
         }
     }
 


### PR DESCRIPTION
Pattern matching captures all the different methods available for Frag. Therefore the catchall won't be triggered which results in a build error.