### PR TITLE
log speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "a flash-sympathetic persistent lock-free B+ tree"
 license = "Apache-2.0"
 homepage = "https://github.com/spacejam/rsdb"
 keywords = ["database", "embedded", "concurrent", "persistent", "lock-free"]
+documentation = "https://docs.rs/rsdb/"
 
 [dependencies]
 bincode = "0.8"
@@ -14,6 +15,8 @@ serde_derive = "1.0"
 libc = "0.2"
 time = "0.1"
 rand = "0.3"
+env_logger = "0.4"
+log = "0.3"
 
 [dev-dependencies]
 quickcheck = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ extern crate serde_derive;
 extern crate bincode;
 extern crate time;
 extern crate rand;
+extern crate env_logger;
+#[macro_use]
+extern crate log as logger;
 
 // atomic lock-free tree
 pub use tree::Tree;
@@ -71,4 +74,14 @@ type Value = Vec<u8>;
 #[inline(always)]
 fn raw<T>(t: T) -> *const T {
     Box::into_raw(Box::new(t)) as *const T
+}
+
+// get thread identifier
+#[inline(always)]
+fn tn() -> String {
+    use std::thread;
+    thread::current()
+        .name()
+        .unwrap_or("unknown")
+        .to_owned()
 }

--- a/src/log/iobuf.rs
+++ b/src/log/iobuf.rs
@@ -12,6 +12,18 @@ struct IOBuf {
     log_offset: AtomicUsize,
 }
 
+impl Debug for IOBuf {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let header = self.get_header();
+        formatter.write_fmt(format_args!("\n\tIOBuf {{ log_offset: {}, n_writers: {}, offset: \
+                                          {}, sealed: {} }}",
+                                         self.get_log_offset(),
+                                         n_writers(header),
+                                         offset(header),
+                                         is_sealed(header)))
+    }
+}
+
 impl IOBuf {
     fn new(buf_size: usize) -> IOBuf {
         IOBuf {
@@ -58,7 +70,7 @@ impl IOBuf {
 
 pub struct IOBufs {
     bufs: Vec<IOBuf>,
-    current_buf: AtomicUsize,
+    sealed_bufs: AtomicUsize,
     written_bufs: AtomicUsize,
 
     intervals: Mutex<Vec<(LogID, LogID)>>,
@@ -70,26 +82,13 @@ pub struct IOBufs {
 
 impl Debug for IOBufs {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let current_buf = self.current_buf.load(SeqCst);
-        let written = self.written_bufs.load(SeqCst);
-        let slow_writers = current_buf - written >= self.config.get_io_bufs();
-        let idx = current_buf % self.config.get_io_bufs();
-        // load current header value
-        let ref iobuf = self.bufs[idx];
-        let hv = iobuf.get_header();
-        let n_writers = n_writers(hv);
-        let offset = offset(hv);
-        let sealed = is_sealed(hv);
+        let sealed_bufs = self.sealed_bufs.load(SeqCst);
+        let written_bufs = self.written_bufs.load(SeqCst);
 
-        let debug = format!("IOBufs {{ idx: {}, slow_writers: {},  n_writers: {}, \
-                             offset: {}, sealed: {} }}",
-                            idx,
-                            slow_writers,
-                            n_writers,
-                            offset,
-                            sealed);
-
-        fmt::Debug::fmt(&debug, formatter)
+        formatter.write_fmt(format_args!("IOBufs {{ sealed: {}, written: {}, bufs: {:?} }}",
+                                         sealed_bufs,
+                                         written_bufs,
+                                         self.bufs))
     }
 }
 
@@ -122,13 +121,13 @@ impl IOBufs {
 
         let bufs = rep_no_copy![IOBuf::new(config.get_io_buf_size()); config.get_io_bufs()];
 
-        let current_buf = 0;
-        bufs[current_buf].set_log_offset(disk_offset);
+        let sealed_bufs = 0;
+        bufs[sealed_bufs].set_log_offset(disk_offset);
 
         IOBufs {
             file: Mutex::new(file),
             bufs: bufs,
-            current_buf: AtomicUsize::new(current_buf),
+            sealed_bufs: AtomicUsize::new(sealed_bufs),
             written_bufs: AtomicUsize::new(0),
             intervals: Mutex::new(vec![]),
             stable: AtomicUsize::new(disk_offset as usize),
@@ -141,8 +140,8 @@ impl IOBufs {
     }
 
     fn idx(&self) -> usize {
-        let current_buf = self.current_buf.load(SeqCst);
-        current_buf % self.config.get_io_bufs()
+        let sealed_bufs = self.sealed_bufs.load(SeqCst);
+        sealed_bufs % self.config.get_io_bufs()
     }
 
     /// Returns the last stable offset in storage.
@@ -164,28 +163,37 @@ impl IOBufs {
         assert_eq!(buf.len() >> 32, 0);
         assert!(buf.len() <= self.config.get_io_buf_size());
 
+        let mut printed = false;
         let mut spins = 0;
         loop {
-            let written = self.written_bufs.load(SeqCst);
-            let current_buf = self.current_buf.load(SeqCst);
-            let idx = current_buf % self.config.get_io_bufs();
+            let written_bufs = self.written_bufs.load(SeqCst);
+            let sealed_bufs = self.sealed_bufs.load(SeqCst);
+            let idx = sealed_bufs % self.config.get_io_bufs();
 
             spins += 1;
             if spins > 1_000_000 {
-                // println!("{:?} stalling in reserve, idx {}", thread::current().name(), idx);
+                // debug!("{:?} stalling in reserve, idx {}", tn(), idx);
                 spins = 0;
             }
 
-            if written > current_buf {
+            if written_bufs > sealed_bufs {
                 // This can happen because a reservation can finish up
                 // before the sealing thread gets around to bumping
-                // current_buf.
+                // sealed_bufs.
+                if !printed {
+                    // trace!("({:?}) written ahead of sealed, spinning", tn());
+                    printed = true;
+                }
                 continue;
             }
 
-            if current_buf - written > self.config.get_io_bufs() {
+            if sealed_bufs - written_bufs >= self.config.get_io_bufs() - 1 {
                 // if written is too far behind, we need to
                 // spin while it catches up to avoid overlap
+                if !printed {
+                    // trace!("({:?}) old io buffer not written yet, spinning", tn());
+                    printed = true;
+                }
                 continue;
             }
 
@@ -197,7 +205,10 @@ impl IOBufs {
             if is_sealed(header) {
                 // already sealed, start over and hope cur
                 // has already been bumped by sealer.
-                // println!("cur is late to be bumped: {:?}", self);
+                if !printed {
+                    // trace!("({:?}) io buffer already sealed, spinning", tn());
+                    printed = true;
+                }
                 continue;
             }
 
@@ -208,6 +219,10 @@ impl IOBufs {
                 // Try to seal the buffer, and maybe write it if
                 // there are zero writers.
                 self.maybe_seal_and_write_iobuf(idx, header);
+                if !printed {
+                    // trace!("({:?}) io buffer too full, spinning", tn());
+                    printed = true;
+                }
                 continue;
             }
 
@@ -218,6 +233,10 @@ impl IOBufs {
 
             if iobuf.cas_header(header, claimed).is_err() {
                 // CAS failed, start over
+                if !printed {
+                    // trace!("({:?}) CAS failed while claiming buffer slot, spinning", tn());
+                    printed = true;
+                }
                 continue;
             }
 
@@ -225,23 +244,13 @@ impl IOBufs {
             // the writer count should be positive
             assert!(n_writers(claimed) != 0);
 
-            let mut spins = 0;
-            let mut log_offset: LogID;
-            loop {
-                log_offset = iobuf.get_log_offset();
-
-                // if we're giving out a reservation, it should
-                // be for an initialized buffer.
-                if log_offset as usize != std::usize::MAX {
-                    break;
-                }
-
-                spins += 1;
-                if spins == 1_000_000 {
-                    // println!("stalling while waiting on log_offset to be reset by last writer.");
-                    spins = 0;
-                }
-            }
+            let log_offset = iobuf.get_log_offset();
+            assert_ne!(log_offset as usize,
+                       std::usize::MAX,
+                       "({:?}) fucked up on idx {}\n{:?}",
+                       tn(),
+                       idx,
+                       self);
 
             let mut out_buf = unsafe { (*iobuf.buf.get()).as_mut_slice() };
 
@@ -272,7 +281,7 @@ impl IOBufs {
         loop {
             spins += 1;
             if spins > 10 {
-                // println!("{:?} have spun >10x in decr", thread::current().name());
+                // debug!("{:?} have spun >10x in decr", tn());
                 spins = 0;
             }
 
@@ -305,7 +314,7 @@ impl IOBufs {
     pub(super) fn flush(&self) {
         let idx = self.idx();
         let header = self.bufs[idx].get_header();
-        if offset(header) == 0 {
+        if offset(header) == 0 || is_sealed(header) {
             // nothing to write, don't bother sealing
             // current IO buffer.
             return;
@@ -324,15 +333,49 @@ impl IOBufs {
             return;
         }
 
+        // NB need to do this before CAS because it can get
+        // written and reset by another thread afterward
+        let log_offset = iobuf.get_log_offset();
+
         let sealed = mk_sealed(header);
 
         if iobuf.cas_header(header, sealed).is_err() {
             // cas failed, don't try to continue
             return;
         }
+        // trace!("({:?}) {} sealed", tn(), idx);
 
         // open new slot
-        self.current_buf.fetch_add(1, SeqCst);
+        let res_len = offset(sealed) as usize;
+        let max = std::usize::MAX as LogID;
+
+        // FIXME triggered by flush()
+        assert_ne!(log_offset,
+                   max,
+                   "({:?}) sealing something that should never have been claimed (idx {})\n{:?}",
+                   tn(),
+                   idx,
+                   self);
+        let next_offset = log_offset + res_len as LogID;
+        let next_idx = (idx + 1) % self.config.get_io_bufs();
+        let ref next_iobuf = self.bufs[next_idx];
+
+        let mut spins = 0;
+        while next_iobuf.cas_log_offset(max, next_offset).is_err() {
+            spins += 1;
+            if spins > 1_000_000 {
+                // debug!("have spun >1,000,000x in seal of buf {}", idx);
+                spins = 0;
+            }
+        }
+        // trace!("({:?}) {} log set", tn(), next_idx);
+
+        // NB allows new threads to start writing into this buffer
+        next_iobuf.set_header(0);
+        // trace!("({:?}) {} zeroed header", tn(), next_idx);
+
+        let sealed_bufs = self.sealed_bufs.fetch_add(1, SeqCst) + 1;
+        // trace!("({:?}) {} sealed_bufs", tn(), sealed_bufs % self.config.get_io_bufs());
 
         // if writers is 0, it's our responsibility to write the buffer.
         if n_writers(sealed) == 0 {
@@ -352,7 +395,8 @@ impl IOBufs {
 
         assert_ne!(log_offset as usize,
                    std::usize::MAX,
-                   "created reservation for uninitialized slot");
+                   "({:?}) created reservation for uninitialized slot",
+                   tn());
 
         let res_len = offset(header) as usize;
         let data = unsafe { (*iobuf.buf.get()).as_mut_slice() };
@@ -364,36 +408,11 @@ impl IOBufs {
         // signal that this IO buffer is uninitialized
         let max = std::usize::MAX as LogID;
         iobuf.set_log_offset(max);
-
-        // We spin here on trying to set the next buffer's disk offset.
-        // We need to spin here because we have the information about where
-        // its disk offset should be, and we choose to block here instead of when
-        // we write it in the future and it's not set up yet.
-        // Its offset is set to usize::MAX after it has been sucessfully written,
-        // so we must wait for this to be true before setting the new disk offset,
-        // otherwise we will alter the offset of pending writes.
-        let next_offset = log_offset + res_len as LogID;
-
-        let mut spins = 0;
-        loop {
-            spins += 1;
-            if spins > 1_000_000 {
-                // println!("{:?} have spun >1,000,000x in seal of buf {}", thread::current().name(), idx);
-                spins = 0;
-            }
-            if self.bufs[(idx + 1) % self.config.get_io_bufs()]
-                .cas_log_offset(max, next_offset)
-                .is_ok() {
-                // success, now we can stop stalling and do other work
-                break;
-            }
-        }
-
-        // NB allows new threads to start writing into this buffer
-        iobuf.set_header(0);
+        // trace!("({:?}) {} log <- MAX", tn(), idx);
 
         // communicate to other threads that we have written an IO buffer.
-        self.written_bufs.fetch_add(1, SeqCst);
+        let written_bufs = self.written_bufs.fetch_add(1, SeqCst);
+        // trace!("({:?}) {} written", tn(), written_bufs % self.config.get_io_bufs());
 
         self.mark_interval(interval);
     }

--- a/src/log/iobuf.rs
+++ b/src/log/iobuf.rs
@@ -191,7 +191,7 @@ impl IOBufs {
                 continue;
             }
 
-            if current_buf - written_bufs >= self.config.get_io_bufs() - 1 {
+            if current_buf - written_bufs >= self.config.get_io_bufs() {
                 // if written is too far behind, we need to
                 // spin while it catches up to avoid overlap
                 trace_once!("({:?}) old io buffer not written yet, spinning", tn());

--- a/src/log/iobuf.rs
+++ b/src/log/iobuf.rs
@@ -342,7 +342,6 @@ impl IOBufs {
         let res_len = offset(sealed) as usize;
         let max = std::usize::MAX as LogID;
 
-        // FIXME triggered by flush()
         assert_ne!(log_offset,
                    max,
                    "({:?}) sealing something that should never have been claimed (idx {})\n{:?}",

--- a/src/log/lss.rs
+++ b/src/log/lss.rs
@@ -89,7 +89,7 @@ impl Log for LockFreeLog {
             self.iobufs.flush();
             spins += 1;
             if spins > 2000000 {
-                println!("have spun >2000000x in make_stable");
+                debug!("have spun >2000000x in make_stable");
                 spins = 0;
             }
             let cur = self.iobufs.stable();

--- a/src/log/lss.rs
+++ b/src/log/lss.rs
@@ -51,10 +51,9 @@ impl Log for LockFreeLog {
         let mut len_buf = [0u8; 4];
         f.read_exact(&mut len_buf)?;
         let len = ops::array_to_usize(len_buf);
-        if len > MAX_BUF_SZ {
-            let msg = format!("read invalid message length, {} should be <= {}",
-                              len,
-                              MAX_BUF_SZ);
+        let max = self.config().get_io_buf_size() - HEADER_LEN;
+        if len > max {
+            let msg = format!("read invalid message length, {} should be <= {}", len, max);
             return Err(Error::new(ErrorKind::Other, msg));
         }
 
@@ -90,7 +89,7 @@ impl Log for LockFreeLog {
             self.iobufs.flush();
             spins += 1;
             if spins > 2000000 {
-                // println!("{:?} have spun >2000000x in make_stable", thread::current().name());
+                println!("have spun >2000000x in make_stable");
                 spins = 0;
             }
             let cur = self.iobufs.stable();

--- a/src/log/reservation.rs
+++ b/src/log/reservation.rs
@@ -9,8 +9,6 @@ pub struct Reservation<'a> {
     pub base_disk_offset: LogID,
 }
 
-unsafe impl<'a> Send for Reservation<'a> {}
-
 impl<'a> Drop for Reservation<'a> {
     fn drop(&mut self) {
         // We auto-abort if the user never uses a reservation.

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -120,7 +120,7 @@ fn non_contiguous_flush() {
 }
 
 #[test]
-fn basic_functionality() {
+fn concurrent_logging() {
     // TODO linearize res bufs, verify they are correct
     let log = Arc::new(Config::default().log());
     let iobs2 = log.clone();


### PR DESCRIPTION
~40% perf improvement by assigning the next log file offset at the time of sealing a buffer

cleanup of remaining code relying on hardcoded constants

some debugging improvements, log support (you won't see these log messages unless you call `env_logger::init();` in your code, but adding these messages makes seeing info easier in the future when debugging)