### PR TITLE
Add padding for keys and values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [features]
 default = ["rayon", "zstd", "libc"]
-bench = ["clap", "num_cpus", "env_logger", "rayon", "zstd"]
+bench = ["clap", "num_cpus", "log", "rand", "rayon", "zstd", "env_logger"]
 race = ["docopt", "chan-signal", "rand", "rayon", "env_logger"]
 
 [[bin]]

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -283,14 +283,19 @@ struct KV {
 impl KV {
     /// creates a new Key-Value instance
     fn new() -> KV {
-        let key: Vec<u8> = rand::thread_rng()
+        let mut key: Vec<u8> = rand::thread_rng()
             .gen_iter::<u8>()
-            .take(64)
+            .take(2)
             .collect::<Vec<u8>>();
-        let value: Vec<u8> = rand::thread_rng()
+        let mut value: Vec<u8> = rand::thread_rng()
             .gen_iter::<u8>()
-            .take(512)
+            .take(2)
             .collect::<Vec<u8>>();
+        let mut key_padding: Vec<u8> = vec![0; 62];
+        let mut value_padding: Vec<u8> = vec![0; 510];
+
+        key.append(&mut key_padding);
+        value.append(&mut value_padding);
 
         KV {
             key,

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -2,7 +2,6 @@ extern crate clap;
 extern crate num_cpus;
 #[macro_use]
 extern crate log;
-extern crate rayon;
 extern crate rand;
 extern crate rsdb;
 


### PR DESCRIPTION
Adds padding for keys and values so that it's more likely to e.g. `get` a previously inserted tree entry.

This way we don't have to seed the tree with dummy data before running the benchmarking tool.