### PR TITLE
implement Send and Sync on types that are used in shared structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsdb"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Tyler Neely <t@jujit.su>"]
 description = "a flash-sympathetic persistent lock-free B+ tree, pagecache, and log"
 license = "Apache-2.0"

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -56,11 +56,15 @@ impl<T> Drop for Node<T> {
 }
 
 /// A simple lock-free radix tree.
-pub struct Radix<T> {
+pub struct Radix<T>
+    where T: Send + Sync
+{
     head: Atomic<Node<T>>,
 }
 
-impl<T> Default for Radix<T> {
+impl<T> Default for Radix<T>
+    where T: Send + Sync
+{
     fn default() -> Radix<T> {
         let head = Owned::new(Node::default());
         Radix {
@@ -69,7 +73,9 @@ impl<T> Default for Radix<T> {
     }
 }
 
-impl<T> Drop for Radix<T> {
+impl<T> Drop for Radix<T>
+    where T: Send + Sync
+{
     fn drop(&mut self) {
         unsafe {
             unprotected(|scope| {
@@ -80,7 +86,9 @@ impl<T> Drop for Radix<T> {
     }
 }
 
-impl<T> Radix<T> {
+impl<T> Radix<T>
+    where T: Send + Sync
+{
     /// Try to create a new item in the tree.
     pub fn insert(&self, pid: PageID, item: T) -> Result<(), ()> {
         pin(|scope| {


### PR DESCRIPTION
I've added `Send` as a requirement for `Stack` and `Radix` contained types, as they may be transmitted to another thread. I've added `Sync` as a requirment for anything that is iterated over in the `Stack` as multiple threads may view references to it simultaneously. I've added `Sync as a requirement for anything contained in a `Radix` as it may be retrieved by multiple threads simultaneously. 
